### PR TITLE
Add CazaProducto

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Directories 🌟🌟🌟
 - Indie Page https://indiepa.ge/ 💸 + 💰
 - StartupResources https://startupresources.io/ 💸
 - 1000.tools https://1000.tools/ 💸
+- CazaProducto https://cazaproducto.com/ 💸 + 😀 (Product Hunt style launch board for the LatAm maker scene)
 
 Directories 🌟🌟
 ------


### PR DESCRIPTION
CazaProducto (https://cazaproducto.com) is a launch board for Latin American makers — think Product Hunt but region-focused. Adding it to the top directories list.